### PR TITLE
fix path,_dirname not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
+var path = require("path");
 var fs = require('fs');
-hexo.extend.filter.register('before_post_render', function(data){
-    var file_content = fs.readFileSync(path.join(_dirname,"./push.js"),"utf-8");
+hexo.extend.filter.register('after_post_render', function(data){
+    var file_content = fs.readFileSync(path.join(__dirname,"./push.js"),"utf-8");
         data.content += file_content;
     return data;
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-baidu-url-push",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A hexo plugin, using Baidu JS automatic link push method, submit links to Baidu",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
使用after_post_render代替before_post_render,
详细可以看我的gitpage页面，这是使用after_post_render 渲染的
如果使用 before_post_render 的话，会发现 这个script脚本会在最后一个<p>中间，特别蛋疼.
view-source:https://jin10086.github.io/2018/02/03/github%E5%A6%82%E4%BD%95%E5%88%9B%E5%BB%BAssh-key/